### PR TITLE
fix variable type error

### DIFF
--- a/modules/ram-user/main.tf
+++ b/modules/ram-user/main.tf
@@ -52,7 +52,7 @@ resource "alicloud_ram_access_key" "this" {
 }
 
 resource "alicloud_ram_access_key" "this_no_pgp" {
-  count = var.create_user && var.create_ram_access_key == "" ? 1 : 0
+  count = var.create_user && var.create_ram_access_key ? 1 : 0
 
   secret_file = var.secret_file != "" ? var.secret_file : null
   status      = var.status


### PR DESCRIPTION
var.create_ram_access_key  and var.create_user are bool type, should not use `==` as string