### PR TITLE
Update and rename mian.tf to main.tf

### DIFF
--- a/modules/ram-group-with-policies/main.tf
+++ b/modules/ram-group-with-policies/main.tf
@@ -1,5 +1,4 @@
 provider "alicloud" {
-  version                 = ">=1.64.0"
   profile                 = var.profile != "" ? var.profile : null
   shared_credentials_file = var.shared_credentials_file != "" ? var.shared_credentials_file : null
   region                  = var.region != "" ? var.region : null


### PR DESCRIPTION
- typo in filename
- Version constraints inside provider configuration blocks are deprecated
> Terraform 0.13 and earlier allowed provider version constraints inside the provider configuration block, but that is now deprecated and will be removed in a future version of Terraform. To silence this warning, move the provider version constraint into the required_providers block.